### PR TITLE
test: add support for Houdini 20.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,28 +7,36 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        houdini_version: [19.5]
-
-    runs-on: ubuntu-latest
+        houdini-version: ["20.0", "19.5"]
+        include:
+          - houdini-version: "20.0"
+            python-version: "3.10"
+          - houdini-version: "19.5"
+            python-version: "3.9"
     container:
-      image: captainhammy/hython-runner:${{ matrix.houdini_version }}
+      image: captainhammy/hython-runner:${{ matrix.houdini-version }}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: pypy${{ matrix.python-version }}
+
       - name: Install Apprentice Licenses
-        uses: captainhammy/install-houdini-apprentice-license-action@v4
+        uses: captainhammy/install-houdini-apprentice-license-action@v5
 
         with:
           client_id: ${{ secrets.SESI_CLIENT_ID }}
           client_secret_key: ${{ secrets.SESI_SECRET_KEY }}
-          houdini_version: ${{ matrix.houdini_version }}
 
       - name: Install dependencies
-        run: python3 -m pip install tox tox-gh-actions
+        run: python${{ matrix.python-version }} -m pip install tox tox-gh-actions
 
       - name: Test with tox
         run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ skipsdist = true
 
 [gh-actions]
 python =
-    3: py3, black-check, flake8, isort-check, mypy, pylint
+    3.9: py39, black-check, flake8, isort-check, mypy, pylint
+    3.10: py310, black-check, flake8, isort-check, mypy, pylint
 
 [pytest]
 pythonpath = src
@@ -30,13 +31,29 @@ allowlist_externals=
     env
     hython
 deps = .[test]
+setenv =
+    # Extra args to pass to the Hython command.  This is really only useful for local testing using
+    # my (Graham's) setup which relies on selecting the Houdini version via wrapper arg. When things
+    # are run automatically on Github the expected Houdini version is already sourced.
+    hython_extra=
+
 commands =
     coverage erase
-    # We need to force in the tox env as we won't be using the created venv and thus won't get the packages added to
-    # the path.
-    env PYTHONPATH={envsitepackagesdir} hython -m pytest tests/
+    # We need to force in the tox env as we won't be using the created venv and thus won't get the
+    # packages added to the path.
+    env PYTHONPATH={envsitepackagesdir} hython {env:hython_extra} -m pytest tests/
     echo "View test coverage report at file://{toxinidir}/coverage_html_report/index.html"
     coverage report --fail-under=100 --skip-covered
+
+[testenv:h195]
+basepython=py39
+setenv =
+  hython_extra=--version 19.5
+
+[testenv:h20]
+basepython=py310
+setenv =
+  hython_extra=--version 20.0
 
 [testenv:black-check]
 deps = black


### PR DESCRIPTION
To do this (and make future versions easier) the testing is converted to a more Houdin version-centric approach rather than the Python version. This has some additional requirements:

Local Testing:

For local testing, the tox targets have been renamed from using the standard Python names (py39, py310, etc) to the Houdini versions (h195, h20). Since I use Houdini via rez, in order to select a version I need to pass along a version qualifier to ensure that the correct version is launched so this is now accomplished via an extra env var (defaulting to empty) that the Houdini specific targets can set and will be added to the hython command. Since the Github targets rely on Houdini already being available and set up they will not care about this and will function as expected.

Github Actions:

For Github, the version is now chosen via a matrix on the major.minor version. As specific versions of Python are still needed, we specify that via matching include fields. We also need to add a new 3.10 gh-actions tox entry to execute with py310.

We also bump the version of install-houdini-apprentice-license-action to 5 in order to no longer need to specify a Houdini version for the license. This change necessitates that we ensure the setup-python action is called before the license action as that is no longer setting up the python that it needs.

fixes: #4